### PR TITLE
Version bump for dynamo formatters.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   lazy val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "2.2.0"
   lazy val upickle = "com.lihaoyi" %% "upickle" % "3.1.3"
   lazy val dynamoClient = "uk.gov.nationalarchives" %% "da-dynamodb-client" % "0.1.23"
-  lazy val dynamoFormatters = "uk.gov.nationalarchives" %% "dynamo-formatters" % "0.0.2"
+  lazy val dynamoFormatters = "uk.gov.nationalarchives" %% "dynamo-formatters" % "0.0.3"
   lazy val s3Client = "uk.gov.nationalarchives" %% "da-s3-client" % "0.1.17"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.17"
   lazy val wiremock = "com.github.tomakehurst" % "wiremock" % "3.0.1"

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -105,7 +105,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
           <opex:Folder>Representation_Preservation</opex:Folder>
         </opex:Folders>
         <opex:Files>
-          <opex:File type="metadata" size="2443">68b1c80b-36b8-4f0f-94d6-92589002d87e.xip</opex:File>
+          <opex:File type="metadata" size="2463">68b1c80b-36b8-4f0f-94d6-92589002d87e.xip</opex:File>
           <opex:File type="content" size="1">Representation_Preservation/a25d33f3-7726-4fb3-8e6f-f66358451c4e/Generation_1/a25d33f3-7726-4fb3-8e6f-f66358451c4e.docx</opex:File>
           <opex:File type="content" size="2">Representation_Preservation/feedd76d-e368-45c8-96e3-c37671476793/Generation_1/feedd76d-e368-45c8-96e3-c37671476793.json</opex:File>
         </opex:Files>


### PR DESCRIPTION
This updates the checksum field name.

The test had to be changed because the xip file is bigger now that it's
pulling in the correct field.

The tests won't pass until
https://github.com/nationalarchives/dr2-dynamo-formatters/pull/3 is
deployed.
